### PR TITLE
Make error/warning message less offensive.

### DIFF
--- a/src/theme.c
+++ b/src/theme.c
@@ -365,7 +365,7 @@ void read_custom_theme(const char *path) {
 
     FILE *f = fopen(path, "r");
     if (!f) {
-        perror("whad de fug DDD-xx");
+        perror("warning");
         return;
     }
 

--- a/src/theme.c
+++ b/src/theme.c
@@ -360,12 +360,12 @@ uint32_t try_parse_hex_colour(char *colour, int *error) {
 }
 
 void read_custom_theme(const char *path) {
-    puts("hello");
+    puts("Loading custom theme:");
     puts(path);
 
     FILE *f = fopen(path, "r");
     if (!f) {
-        perror("warning");
+        perror("error: failed to open theme");
         return;
     }
 
@@ -397,7 +397,7 @@ void read_custom_theme(const char *path) {
         uint32_t col = try_parse_hex_colour(colour, &err);
 
         if (err) {
-            puts("error");
+            puts("error: parsing hex colour failed");
             continue;
         } else {
             *colourp = COLOR_PROC(col);


### PR DESCRIPTION
uTox prints "whad de fug DDD-xx" on console if it cannot open a file, this can be deemed offensive and unprofessional. Worst case this could hinder adoption of uTox. As uTox continues running fine afterwards change it to: "warning".

While personally this wouldn't stop me from using uTox, I don't know how others feel about it. Better safe than sorry. It seems there are some more "funny" error messages in uTox, but as they weren't offensive I left them in.